### PR TITLE
Don't modify the buffer while parsing it

### DIFF
--- a/lib/elf-reader.js
+++ b/lib/elf-reader.js
@@ -50,7 +50,7 @@ function parse(image) {
       // Node v10 no longer allows reads > 6 bytes
       if (sz > 6) {
         let buf = this.image.slice(this.idx, this.idx += sz);
-        if (this.endian === 'lsb') buf = buf.reverse();
+        if (this.endian === 'lsb') buf = Buffer.from(buf).reverse();
         const hex = buf.toString('hex').match(/[^0].*|0$/)[0];
         const n = parseInt(hex, 16);
         // sanity check


### PR DESCRIPTION
I guess this could use `readBigUInt64BE`/`readBigUInt64LE` now. Or do you want to support older node versions ?